### PR TITLE
add --deep to codesign

### DIFF
--- a/math-with-slack.py
+++ b/math-with-slack.py
@@ -296,8 +296,8 @@ def macos_codesign_app(cert, workdir, app_path):
 
   subprocess.check_call(
       [
-          "codesign", "--entitlements", entitlements_path, "--force", "--sign",
-          cert, slack_app_path
+          "codesign", "--entitlements", entitlements_path, "--deep", "--force",
+          "--sign", cert, slack_app_path
       ],
       stdout=subprocess.DEVNULL,
   )


### PR DESCRIPTION
Seems to fix the error:
```
/Applications/Slack.app: replacing existing signature
/Applications/Slack.app: code object is not signed at all
```

 Might also happen to fix #35 